### PR TITLE
Add incremental APs and disable Google Play services plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,13 @@
  */
 
 buildscript {
-    ext.kotlin = '1.3.40'
+    ext.kotlin = '1.3.50-eap-54'
     ext.spotless = '3.15.0'
     ext.ktlint = '0.28.0'
     ext.googlejavaformat = '1.6'
 
     repositories {
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         google()
         jcenter()
     }
@@ -64,12 +65,12 @@ ext {
     supportWearable = "com.google.android.support:wearable:2.3.0"
     providedWear = "com.google.android.wearable:wearable:2.3.0"
 
-    archLifecycle = '2.0.0'
+    archLifecycle = '2.2.0-alpha02'
     archLifecycleRuntime = "androidx.lifecycle:lifecycle-runtime:$archLifecycle"
     archLifecycleExtentions = "androidx.lifecycle:lifecycle-extensions:$archLifecycle"
     archLifecycleCompiler = "androidx.lifecycle:lifecycle-compiler:$archLifecycle"
 
-    archRoom = "2.0.0"
+    archRoom = "2.2.0-alpha01"
     archRoomRuntime = "androidx.room:room-runtime:$archRoom"
     archRoomCompiler = "androidx.room:room-compiler:$archRoom"
     archRoomTesting = "androidx.room:room-testing:$archRoom"
@@ -95,7 +96,7 @@ ext {
     firebaseMessaging = 'com.google.firebase:firebase-messaging:17.3.3'
     firebaseStorage = 'com.google.firebase:firebase-storage:16.0.1'
 
-    dagger = '2.17'
+    dagger = '2.23.2'
     daggerCore = "com.google.dagger:dagger:$dagger"
     daggerAndroid = "com.google.dagger:dagger-android:$dagger"
     daggerAndroidSupport = "com.google.dagger:dagger-android-support:$dagger"
@@ -175,6 +176,7 @@ subprojects {
     }
 
     repositories {
+        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         google()
         mavenCentral()
         jcenter()

--- a/santa-tracker/build.gradle
+++ b/santa-tracker/build.gradle
@@ -160,5 +160,5 @@ dependencies {
     androidTestImplementation rootProject.ext.testingSupportRules
 }
 
-apply plugin: 'com.google.gms.google-services'
+//apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'

--- a/santa-tracker/build.gradle
+++ b/santa-tracker/build.gradle
@@ -35,6 +35,15 @@ android {
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         wearAppUnbundled true
+
+	javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = [
+                   "dagger.gradle.incremental": "true",
+                   "room.incremental":"true"
+                ]
+            }
+        }
     }
 
     buildTypes {

--- a/tracker/build.gradle
+++ b/tracker/build.gradle
@@ -29,7 +29,11 @@ android {
 
         javaCompileOptions {
             annotationProcessorOptions {
-                arguments = ["room.schemaLocation": "$projectDir/schemas".toString()]
+	        arguments = [
+                   "room.schemaLocation": "$projectDir/schemas".toString(),
+                   "room.incremental": "true",
+                   "dagger.gradle.incremental": "true"
+                ]
             }
         }
     }

--- a/tracker/src/main/java/com/google/android/apps/santatracker/tracker/ui/TrackerMapFragment.kt
+++ b/tracker/src/main/java/com/google/android/apps/santatracker/tracker/ui/TrackerMapFragment.kt
@@ -202,7 +202,7 @@ class TrackerMapFragment : SupportMapFragment(), SantaMarker.SantaMarkerInterfac
         visitedDestinations = state.visitedDestinations
     }
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
         val activity = activity ?: return
         soundPlayer = TrackerSoundPlayer(activity)


### PR DESCRIPTION
This PR updates APs to versions that support incremental annotation processing. Also a `santa-tracker/mock-google-services.json` file is added in order to avoid creating an actual Firebase project when building the project.