### PR TITLE
Additional scenarios for nonAbiChange and upToDate

### DIFF
--- a/performance-base.conf
+++ b/performance-base.conf
@@ -20,6 +20,14 @@ measureSnapshottingOps {
     ]
 }
 
+disableBuildScan {
+	gradle-args = ["-PdisableBuildScan"]
+}
+
+disableBuildCache {
+  gradle-args = ["--no-build-cache"]
+}
+
 cleanBuild {
 	tasks = [":santa-tracker:assembleDebug"]
 	cleanup-tasks = ["clean"]
@@ -39,6 +47,8 @@ upToDate {
 }
 
 upToDateWithSnapshottingOps = ${upToDate} ${measureSnapshottingOps}
+upToDateWithSnapshottingOpsDisableBuildScan = ${upToDate} ${measureSnapshottingOps} ${disableBuildScan}
+upToDateWithSnapshottingOpsDisableBuildCache = ${upToDate} ${measureSnapshottingOps} ${disableBuildCache}
 
 abiChange {
 	tasks = [":santa-tracker:assembleDebug"]
@@ -56,6 +66,8 @@ nonAbiChange {
 }
 
 nonAbiChangeWithSnapshottingOps = ${nonAbiChange} ${measureSnapshottingOps}
+nonAbiChangeWithSnapshottingOpsDisableBuildScan = ${nonAbiChange} ${measureSnapshottingOps} ${disableBuildScan}
+nonAbiChangeWithSnapshottingOpsDisableBuildCache = ${nonAbiChange} ${measureSnapshottingOps} ${disableBuildCache}
 
 resourceChange {
 	tasks = [":santa-tracker:assembleDebug"]


### PR DESCRIPTION
Add scenarios without build scan plugin and without build cache.