### PR TITLE
Remove production flavor

### DIFF
--- a/santa-tracker/build.gradle
+++ b/santa-tracker/build.gradle
@@ -36,8 +36,8 @@ android {
    flavorDimensions "devProd"
 
     productFlavors {
-        production {
-        }
+        // production {
+        // }
         development {
             minSdkVersion 24        // Tip 2
             resConfigs ("en", "xxhdpi")   // Tip 4
@@ -153,7 +153,7 @@ dependencies {
     implementation rootProject.ext.firebaseStorage
 
     developmentImplementation rootProject.ext.leakCanary
-    productionImplementation rootProject.ext.leakCanaryNoOp
+    // productionImplementation rootProject.ext.leakCanaryNoOp
 
     androidTestImplementation rootProject.ext.espressoCore, {
         exclude group: 'com.android.support', module: 'support-annotations'


### PR DESCRIPTION
Remove production flavor so we can use the same task names for both branches of santa-tracker app.