### PR TITLE
Remove special case for CI

### DIFF
--- a/santa-tracker/build.gradle
+++ b/santa-tracker/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 
 ext.densityList = ['mdpi', 'hdpi', 'xhdpi', 'xxhdpi', 'xxxhdpi']
 ext.abiList = ['armeabi', 'armeabi-v7a', 'x86']
-ext.splitEnabled = true
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -56,16 +55,14 @@ android {
         }
     }
 
-    boolean ciBuild = System.getenv("CI")
-    splitEnabled = ciBuild                   // Tip 3
-    aaptOptions.cruncherEnabled = ciBuild    // Tip 5
+    aaptOptions.cruncherEnabled = false
 
 
 
 
    splits {
         abi {
-            enable splitEnabled
+            enable false
 
             // Include the three architectures that we support for snowdown
             reset()


### PR DESCRIPTION
When on CI, the build did an APK split.
Moreover, it switched on the aapt cruncher.

Since we want to have comparable performance results,
the build shouldn't depend on whether it is running
on CI or not.

gradle/gradle#11929