### PR TITLE
Make `build.gradle` conform to `forUseAtConfigurationTime()` rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:${providers.systemProperty("agpVersion").orNull ?: '3.6.0-rc01'}"
+        classpath "com.android.tools.build:gradle:${providers.systemProperty("agpVersion").forUseAtConfigurationTime().orNull ?: '3.6.0-rc01'}"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-milestone-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Starting with Gradle 6.5, providers returned by `ProviderFactory.(systemProperty|gradleProperty|environmentVariable|of)` forbid queries at configuration time by default and require a `forUseAtConfigurationTime()` provider to be used instead.

This PR updates the branch to the latest Gradle 6.5 M1 release which already comes with the new API and makes `build.gradle` conform to it.