### PR TITLE
Add max metaspace JVM arg

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true
 
-org.gradle.jvmargs=-Xmx1g
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m
 org.gradle.workers.max=8
 
 android.useAndroidX=true


### PR DESCRIPTION
Prior to [this upcoming PR](https://github.com/gradle/gradle/pull/20054), setting the jvm args would cause gradle to not set default values for max metaspace. After the PR, gradle detects that the max metaspace was not set and sets a lower default than the JVM would set automatically. 

Here, we explicitly set the max metaspace argument to a sufficient value, since the new default that will be set after the above linked PR is not sufficient. 