### PR TITLE
Update build for Kotlin 1.8.0-RC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,15 @@ subprojects {
     pluginManager.withPlugin("java-base") {
         java {
             toolchain {
-                languageVersion.set(JavaLanguageVersion.of(8))
+                languageVersion.set(JavaLanguageVersion.of(11))
+            }
+        }
+    }
+    pluginManager.withPlugin("com.android.base") {
+        android {
+            compileOptions {
+                sourceCompatibility JavaVersion.VERSION_11
+                targetCompatibility JavaVersion.VERSION_11
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -175,4 +175,12 @@ subprojects {
         google()
         mavenCentral()
     }
+
+    pluginManager.withPlugin("java-base") {
+        java {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(8))
+            }
+        }
+    }
 }

--- a/cityquiz/build.gradle
+++ b/cityquiz/build.gradle
@@ -25,11 +25,6 @@ android {
         buildConfig = true
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -27,11 +27,6 @@ android {
         viewBinding = true
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,7 +17,6 @@
 apply plugin: 'com.android.library'
 
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -25,6 +24,7 @@ android {
 
     buildFeatures {
         buildConfig = true
+        viewBinding = true
     }
 
     compileOptions {

--- a/dasherdancer/build.gradle
+++ b/dasherdancer/build.gradle
@@ -21,11 +21,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/doodles-lib/build.gradle
+++ b/doodles-lib/build.gradle
@@ -20,11 +20,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/gumball/build.gradle
+++ b/gumball/build.gradle
@@ -20,11 +20,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/jetpack/build.gradle
+++ b/jetpack/build.gradle
@@ -21,11 +21,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/memory/build.gradle
+++ b/memory/build.gradle
@@ -20,11 +20,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/penguinswim/build.gradle
+++ b/penguinswim/build.gradle
@@ -20,11 +20,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/playgames/build.gradle
+++ b/playgames/build.gradle
@@ -20,11 +20,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/presentquest/build.gradle
+++ b/presentquest/build.gradle
@@ -20,11 +20,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/presenttoss/build.gradle
+++ b/presenttoss/build.gradle
@@ -20,11 +20,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/rocketsleigh/build.gradle
+++ b/rocketsleigh/build.gradle
@@ -25,11 +25,6 @@ android {
         buildConfig = true
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/santa-tracker/build.gradle
+++ b/santa-tracker/build.gradle
@@ -17,7 +17,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
 
 ext.abiList = ['armeabi', 'armeabi-v7a', 'x86']
 
@@ -27,6 +26,7 @@ android {
 
     buildFeatures {
         buildConfig = true
+        viewBinding = true
     }
 
     compileOptions {

--- a/santa-tracker/build.gradle
+++ b/santa-tracker/build.gradle
@@ -29,11 +29,6 @@ android {
         viewBinding = true
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         applicationId "com.google.android.apps.santatracker"
 

--- a/santa-tracker/src/main/java/com/google/android/apps/santatracker/games/SplashActivity.kt
+++ b/santa-tracker/src/main/java/com/google/android/apps/santatracker/games/SplashActivity.kt
@@ -38,14 +38,12 @@ import androidx.core.view.isVisible
 import com.bumptech.glide.Glide
 import com.google.android.apps.santatracker.BuildConfig
 import com.google.android.apps.santatracker.R
+import com.google.android.apps.santatracker.databinding.ActivitySplashBinding
 import com.google.android.apps.santatracker.util.ImmersiveModeHelper
 import com.google.android.play.core.splitinstall.SplitInstallHelper
 import com.google.android.play.core.splitinstall.SplitInstallManager
 import com.google.android.play.core.splitinstall.SplitInstallManagerFactory
 import com.google.android.play.core.splitinstall.SplitInstallRequest
-import kotlinx.android.synthetic.main.activity_splash.progressbar
-import kotlinx.android.synthetic.main.activity_splash.splash_image
-import kotlinx.android.synthetic.main.activity_splash.splash_title
 
 /**
  * Splash screen for games. The splash screen rotates at runtime to match the orientation of the
@@ -58,6 +56,8 @@ class SplashActivity : AppCompatActivity() {
 
     private var activityClassName: String? = null
 
+    private lateinit var binding: ActivitySplashBinding
+
     private val splitInstallManager: SplitInstallManager by lazy(LazyThreadSafetyMode.NONE) {
         SplitInstallManagerFactory.create(this)
     }
@@ -69,16 +69,16 @@ class SplashActivity : AppCompatActivity() {
             }
 
             override fun onPending() {
-                progressbar.isVisible = true
-                progressbar.isIndeterminate = true
+                binding.progressbar.isVisible = true
+                binding.progressbar.isIndeterminate = true
             }
 
             override fun onDownloading(bytesDownloaded: Long, totalBytesToDownload: Long) {
                 if (bytesDownloaded >= (totalBytesToDownload * MIN_PROGRESS_DETERMINATE_PERC)) {
-                    progressbar.isIndeterminate = false
+                    binding.progressbar.isIndeterminate = false
                     // Use KB to minimize any overflow issues
-                    progressbar.progress = (bytesDownloaded / 1024).toInt()
-                    progressbar.max = (totalBytesToDownload / 1024).toInt()
+                    binding.progressbar.progress = (bytesDownloaded / 1024).toInt()
+                    binding.progressbar.max = (totalBytesToDownload / 1024).toInt()
                 }
             }
 
@@ -105,6 +105,7 @@ class SplashActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding = ActivitySplashBinding.inflate(layoutInflater)
 
         val gameIsLandscape = intent.getBooleanExtra(EXTRA_LANDSCAPE, false)
         activityClassName = intent.getStringExtra(EXTRA_CLASS_NAME)
@@ -119,23 +120,23 @@ class SplashActivity : AppCompatActivity() {
             return
         }
 
-        setContentView(R.layout.activity_splash)
+        setContentView(binding.root)
 
         // Immersive mode (to hide nav).
         ImmersiveModeHelper.setImmersiveSticky(window)
 
         // Set Image
         val imageTransitionName = intent.getStringExtra(EXTRA_IMAGE_TRANSITION_NAME)
-        splash_image.transitionName = imageTransitionName
+        binding.splashImage.transitionName = imageTransitionName
 
         val splashImageUrl = intent.getStringExtra(EXTRA_SPLASH_IMAGE_URL)
         if (splashImageUrl.isNullOrEmpty()) {
             val splashImageId = intent.getIntExtra(EXTRA_SPLASH_IMAGE_ID, -1)
             if (splashImageId != -1) {
-                Glide.with(splash_image.context).load(splashImageId).into(splash_image)
+                Glide.with(binding.splashImage.context).load(splashImageId).into(binding.splashImage)
             }
         } else {
-            Glide.with(splash_image.context).load(splashImageUrl).into(splash_image)
+            Glide.with(binding.splashImage.context).load(splashImageUrl).into(binding.splashImage)
         }
 
         val splashScreenColorId = intent.getIntExtra(EXTRA_SPLASH_SCREEN_COLOR_ID, -1)
@@ -144,7 +145,7 @@ class SplashActivity : AppCompatActivity() {
             mainView.setBackgroundColor(ContextCompat.getColor(this, splashScreenColorId))
         }
 
-        progressbar.apply {
+        binding.progressbar.apply {
             progressTintList = ContextCompat.getColorStateList(
                     this@SplashActivity, R.color.SantaWhite)
             indeterminateTintList = ContextCompat.getColorStateList(
@@ -153,7 +154,7 @@ class SplashActivity : AppCompatActivity() {
 
         // Set Title
         title = getString(intent.getIntExtra(EXTRA_SPLASH_TITLE_ID, -1))
-        splash_title.text = title
+        binding.splashTitle.text = title
 
         if (intent.hasExtra(EXTRA_DYNAMIC_FEATURE_NAME_ID)) {
             tryLaunchOrInstallModule(SHOW_FAKE_FEATURE_MODULE_DOWNLOAD)
@@ -192,8 +193,8 @@ class SplashActivity : AppCompatActivity() {
     }
 
     private fun startModuleInstall() {
-        progressbar.isVisible = true
-        progressbar.isIndeterminate = true
+        binding.progressbar.isVisible = true
+        binding.progressbar.isIndeterminate = true
 
         // The split isn't installed so lets start the split install request
         installStateListener.register(splitInstallManager)

--- a/snowballrun/build.gradle
+++ b/snowballrun/build.gradle
@@ -20,11 +20,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/tracker/build.gradle
+++ b/tracker/build.gradle
@@ -22,11 +22,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/wearable/build.gradle
+++ b/wearable/build.gradle
@@ -22,11 +22,6 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.tools
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
     defaultConfig {
         applicationId "com.google.android.apps.santatracker"
         minSdkVersion rootProject.ext.minSdkVersion


### PR DESCRIPTION
* Requires Java 11 target for both Java and Kotlin compilation tasks
* Requires replacing KGP's `kotlin-android-extensions` plugin with AGP's view binding
* This works back to AGP 7.3 which is the lowest version tested by `gradle/gradle`
* See https://github.com/gradle/gradle/pull/23047